### PR TITLE
Merge fixes from I2C to SPI driver

### DIFF
--- a/drivers/spi/spi-atmel.c
+++ b/drivers/spi/spi-atmel.c
@@ -1223,6 +1223,8 @@ static int atmel_spi_setup(struct spi_device *spi)
 		csr |= SPI_BIT(CPOL);
 	if (!(spi->mode & SPI_CPHA))
 		csr |= SPI_BIT(NCPHA);
+	else
+		csr | SPI_BF(NCPHA, 0);
 
 	if (!spi->cs_gpiod)
 		csr |= SPI_BIT(CSAAT);


### PR DESCRIPTION
Merges fixes applied to atmel_mxt_ts.c to SPI mchp_mxt_ts.c driver
-- Updates config write routine to allow handling volatile objects and 
missing objects at start of raw file
-- Corrects check to determine if REPORTALL bit has been cleared
-- Adds retry code, if message response to read or write request is in error